### PR TITLE
Update MapCompose to support more zooming gestures

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -95,7 +95,7 @@ dependencies {
     implementation 'androidx.activity:activity-compose:1.5.1'
     implementation 'androidx.navigation:navigation-compose:2.5.1'
     implementation 'androidx.hilt:hilt-navigation-compose:1.0.0'
-    implementation 'ovh.plrapps:mapcompose:2.1.4'
+    implementation 'ovh.plrapps:mapcompose:2.2.2'
     implementation 'com.google.accompanist:accompanist-systemuicontroller:0.25.1'
 
     testImplementation 'junit:junit:4.13.2'

--- a/app/src/main/java/ru/spbu/depnav/ui/map/MapScreenViewModel.kt
+++ b/app/src/main/java/ru/spbu/depnav/ui/map/MapScreenViewModel.kt
@@ -46,6 +46,7 @@ import ovh.plrapps.mapcompose.api.addLayer
 import ovh.plrapps.mapcompose.api.addLazyLoader
 import ovh.plrapps.mapcompose.api.addMarker
 import ovh.plrapps.mapcompose.api.centerOnMarker
+import ovh.plrapps.mapcompose.api.disableFlingZoom
 import ovh.plrapps.mapcompose.api.maxScale
 import ovh.plrapps.mapcompose.api.minScaleSnapshotFlow
 import ovh.plrapps.mapcompose.api.onMarkerClick
@@ -177,6 +178,7 @@ class MapScreenViewModel @Inject constructor(
             setScrollOffsetRatio(0.5f, 0.5f)
             setColorFilterProvider { _, _, _ -> ColorFilter.tint(tileColor) }
             addLazyLoader(LAZY_LOADER_ID, padding = (DEFAULT_PADDING * 2))
+            disableFlingZoom() // Works strange when a lot of markers are loaded simultaneously
             shouldLoopScale = true
 
             onTap { _, _ ->


### PR DESCRIPTION
Applies new MapCompose versions so that now gestures like zooming by double tapping and sliding and zooming out by tapping with two fingers are supported. Closes #31.

The new zoom fling feature is disabled for now as it is currently available only for zooming with two fingers (which feels inconsistent) and requires some tuning (speed needs to be reduced, it can be configured with `MapState.configureGestures()`).