### PR TITLE
Marker clustering

### DIFF
--- a/app/src/main/java/ru/spbu/depnav/data/composite/MarkerWithText.kt
+++ b/app/src/main/java/ru/spbu/depnav/data/composite/MarkerWithText.kt
@@ -1,0 +1,44 @@
+/**
+ * DepNav -- department navigator.
+ * Copyright (C) 2022  Timofei Pushkin
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+package ru.spbu.depnav.data.composite
+
+import ru.spbu.depnav.data.model.Marker
+import ru.spbu.depnav.data.model.MarkerText
+
+/** [Marker] with its corresponding [MarkerText]. */
+data class MarkerWithText(val marker: Marker, val text: MarkerText) {
+    init {
+        require(marker.id == text.markerId) {
+            "Marker ID ${marker.id} != marker text's marker ID ${text.markerId}"
+        }
+    }
+
+    /** ID of this marker as a string. It is parsed by the marker clustering code. */
+    val extendedId by lazy {
+        if (marker.type == Marker.MarkerType.ROOM) {
+            "${marker.id}$ID_DIVIDER${text.title}"
+        } else {
+            "${marker.id}"
+        }
+    }
+
+    companion object {
+        val ID_DIVIDER = ':'
+    }
+}

--- a/app/src/main/java/ru/spbu/depnav/data/model/Marker.kt
+++ b/app/src/main/java/ru/spbu/depnav/data/model/Marker.kt
@@ -21,7 +21,6 @@ package ru.spbu.depnav.data.model
 import androidx.room.ColumnInfo
 import androidx.room.Entity
 import androidx.room.ForeignKey
-import androidx.room.Ignore
 import androidx.room.PrimaryKey
 
 /** Displayable marker. */
@@ -52,10 +51,6 @@ data class Marker(
     /** Y coordinate of this marker. */
     val y: Double
 ) {
-    /** ID of this marker as a string. */
-    @Ignore
-    val idStr = id.toString()
-
     /** Type of an object represented by a [Marker]. */
     enum class MarkerType {
         /** Building entrance. */

--- a/app/src/main/java/ru/spbu/depnav/ui/component/MapSearchBar.kt
+++ b/app/src/main/java/ru/spbu/depnav/ui/component/MapSearchBar.kt
@@ -57,8 +57,7 @@ import androidx.compose.ui.platform.LocalLayoutDirection
 import androidx.compose.ui.platform.LocalSoftwareKeyboardController
 import androidx.compose.ui.res.stringResource
 import ru.spbu.depnav.R
-import ru.spbu.depnav.data.model.Marker
-import ru.spbu.depnav.data.model.MarkerText
+import ru.spbu.depnav.data.composite.MarkerWithText
 import ru.spbu.depnav.ui.theme.DEFAULT_PADDING
 
 // These are basically copied from SearchBar implementation
@@ -87,7 +86,7 @@ fun MapSearchBar(
     onQueryChange: (String) -> Unit,
     active: Boolean,
     onActiveChange: (Boolean) -> Unit,
-    results: Map<Marker, MarkerText>,
+    results: List<MarkerWithText>,
     onResultClick: (Int) -> Unit,
     onInfoClick: () -> Unit,
     onSettingsClick: () -> Unit,

--- a/app/src/main/java/ru/spbu/depnav/ui/component/MarkerCluster.kt
+++ b/app/src/main/java/ru/spbu/depnav/ui/component/MarkerCluster.kt
@@ -1,0 +1,143 @@
+/**
+ * DepNav -- department navigator.
+ * Copyright (C) 2022  Timofei Pushkin
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+package ru.spbu.depnav.ui.component
+
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.sizeIn
+import androidx.compose.material3.Icon
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Surface
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.saveable.rememberSaveable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.painter.Painter
+import androidx.compose.ui.res.painterResource
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.text.style.TextOverflow
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.coerceAtMost
+import androidx.compose.ui.unit.dp
+import ru.spbu.depnav.R
+import ru.spbu.depnav.data.composite.MarkerWithText
+import ru.spbu.depnav.data.model.Marker
+import ru.spbu.depnav.ui.theme.DEFAULT_PADDING
+
+/** Maximum size a marker cluster composable can have in each dimension. */
+val MAX_MARKER_CLUSTER_VIEW_SIZE = 50.dp
+
+@Composable
+fun MarkersCluster(
+    markerIds: List<String>,
+    type: Marker.MarkerType,
+    modifier: Modifier = Modifier
+) = when (type) {
+    Marker.MarkerType.ROOM -> RoomMarkersCluster(markerIds, modifier)
+    Marker.MarkerType.ENTRANCE ->
+        NonRoomMarkersCluster(painterResource(R.drawable.mrk_entrance), modifier)
+    Marker.MarkerType.STAIRS_UP, Marker.MarkerType.STAIRS_DOWN, Marker.MarkerType.STAIRS_BOTH ->
+        NonRoomMarkersCluster(painterResource(R.drawable.mrk_stairs), modifier)
+    Marker.MarkerType.ELEVATOR ->
+        NonRoomMarkersCluster(painterResource(R.drawable.mrk_elevator), modifier)
+    Marker.MarkerType.WC_MAN, Marker.MarkerType.WC_WOMAN, Marker.MarkerType.WC ->
+        NonRoomMarkersCluster(painterResource(R.drawable.mrk_wc), modifier)
+    Marker.MarkerType.OTHER ->
+        NonRoomMarkersCluster(painterResource(R.drawable.mrk_other), modifier)
+}
+
+@Composable
+private fun RoomMarkersCluster(markerIds: List<String>, modifier: Modifier = Modifier) {
+    val title = rememberSaveable {
+        val commonPrefix = markerIds.fold(markerTitleFromExtendedId(markerIds.first())) { acc, s ->
+            val title = markerTitleFromExtendedId(s)
+            acc.commonPrefixWith(title)
+        }
+        "$commonPrefix…"
+    }
+
+    Surface(
+        modifier = Modifier
+            .sizeIn(
+                maxWidth = MAX_MARKER_CLUSTER_VIEW_SIZE,
+                maxHeight = MAX_MARKER_CLUSTER_VIEW_SIZE
+            )
+            .then(modifier),
+        shape = MaterialTheme.shapes.small,
+        color = MaterialTheme.colorScheme.onBackground
+    ) {
+        Box(contentAlignment = Alignment.Center) {
+            Text(
+                title,
+                modifier = Modifier.padding(DEFAULT_PADDING / 4),
+                overflow = TextOverflow.Ellipsis
+            )
+        }
+    }
+}
+
+private fun markerTitleFromExtendedId(extendedId: String) =
+    extendedId.substringAfter(MarkerWithText.ID_DIVIDER, "")
+
+@Composable
+private fun NonRoomMarkersCluster(painter: Painter, modifier: Modifier = Modifier) {
+    Surface(
+        modifier = Modifier
+            .sizeIn(
+                maxWidth = MARKER_ICON_SIZE.coerceAtMost(MAX_MARKER_CLUSTER_VIEW_SIZE),
+                maxHeight = MARKER_ICON_SIZE.coerceAtMost(MAX_MARKER_CLUSTER_VIEW_SIZE)
+            )
+            .then(modifier),
+        shape = MaterialTheme.shapes.extraSmall,
+        color = MaterialTheme.colorScheme.onBackground
+    ) {
+        Box(contentAlignment = Alignment.Center) {
+            Icon(
+                painter = painter,
+                contentDescription = stringResource(R.string.label_non_room_cluster),
+                modifier = Modifier
+                    .size(MARKER_ICON_SIZE) // Will be shrunk by the surface because of the padding
+                    .padding(DEFAULT_PADDING / 4)
+            )
+        }
+    }
+}
+
+@Preview
+@Composable
+@Suppress("UnusedPrivateMember")
+private fun RoomMarkersClusterPreview() {
+    MarkersCluster(
+        markerIds = listOf(
+            "1${MarkerWithText.ID_DIVIDER}1234",
+            "2${MarkerWithText.ID_DIVIDER}1235",
+            "3${MarkerWithText.ID_DIVIDER}1236"
+        ),
+        type = Marker.MarkerType.ROOM
+    )
+}
+
+@Preview
+@Composable
+@Suppress("UnusedPrivateMember")
+private fun NonRoomMarkersClusterPreview() {
+    MarkersCluster(markerIds = listOf("1", "2"), type = Marker.MarkerType.WC)
+}

--- a/app/src/main/java/ru/spbu/depnav/ui/component/MarkerCluster.kt
+++ b/app/src/main/java/ru/spbu/depnav/ui/component/MarkerCluster.kt
@@ -45,6 +45,7 @@ import ru.spbu.depnav.ui.theme.DEFAULT_PADDING
 /** Maximum size a marker cluster composable can have in each dimension. */
 val MAX_MARKER_CLUSTER_VIEW_SIZE = 50.dp
 
+/** Multiple markers clustered together. */
 @Composable
 fun MarkersCluster(
     markerIds: List<String>,

--- a/app/src/main/java/ru/spbu/depnav/ui/component/MarkerView.kt
+++ b/app/src/main/java/ru/spbu/depnav/ui/component/MarkerView.kt
@@ -38,12 +38,13 @@ import ru.spbu.depnav.data.model.Marker
 import ru.spbu.depnav.data.model.Marker.MarkerType
 import ru.spbu.depnav.ui.theme.DepNavTheme
 
-private val ICON_SIZE = 20.dp
+/** Size of marker icon in each dimension. */
+val MARKER_ICON_SIZE = 20.dp
 
 /** Visual representation of a [Marker]. */
 @Composable
 fun MarkerView(
-    title: String,
+    title: String?,
     type: MarkerType,
     isClosed: Boolean,
     modifier: Modifier = Modifier,
@@ -58,7 +59,7 @@ fun MarkerView(
         )
     } else {
         RoomName(
-            name = title,
+            name = requireNotNull(title) { "Room markers must have titles" },
             lineTrough = isClosed,
             modifier = modifier
         )
@@ -130,7 +131,7 @@ private fun MarkerIcon(
         painter = painter,
         contentDescription = contentDescription,
         modifier = Modifier
-            .size(ICON_SIZE)
+            .size(MARKER_ICON_SIZE)
             .alpha(if (faded) 0.38f else 1f)
             .then(modifier)
     )

--- a/app/src/main/java/ru/spbu/depnav/ui/component/SearchResults.kt
+++ b/app/src/main/java/ru/spbu/depnav/ui/component/SearchResults.kt
@@ -48,15 +48,21 @@ import androidx.compose.ui.unit.dp
 import kotlinx.coroutines.flow.launchIn
 import kotlinx.coroutines.flow.onEach
 import ru.spbu.depnav.R
+import ru.spbu.depnav.data.composite.MarkerWithText
 import ru.spbu.depnav.data.model.Marker
 import ru.spbu.depnav.data.model.MarkerText
 import ru.spbu.depnav.ui.theme.DEFAULT_PADDING
 import ru.spbu.depnav.ui.theme.DepNavTheme
 
-/** Column with clickable information about markers that were found by the search. */
+/**
+ * Column with clickable information about markers that were found by the search.
+ *
+ * @param markersWithTexts results sorted by importance: elements listed first will be displayed on
+ * top.
+ */
 @Composable
 fun SearchResults(
-    markersWithTexts: Map<Marker, MarkerText>,
+    markersWithTexts: List<MarkerWithText>,
     isHistory: Boolean,
     onScroll: (onTop: Boolean) -> Unit,
     onResultClick: (Int) -> Unit,
@@ -71,7 +77,7 @@ fun SearchResults(
         contentPadding = PaddingValues(top = DEFAULT_PADDING / 2),
         verticalArrangement = Arrangement.spacedBy(4.dp)
     ) {
-        items(markersWithTexts.toList().asReversed()) { (marker, markerText) ->
+        items(markersWithTexts.asReversed()) { (marker, markerText) ->
             if (markerText.title == null) return@items
 
             SearchResult(

--- a/app/src/main/java/ru/spbu/depnav/ui/screen/MapScreen.kt
+++ b/app/src/main/java/ru/spbu/depnav/ui/screen/MapScreen.kt
@@ -47,6 +47,7 @@ import androidx.compose.material3.Surface
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.CompositionLocalProvider
 import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.derivedStateOf
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
@@ -63,8 +64,7 @@ import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import androidx.lifecycle.viewmodel.compose.viewModel
 import ovh.plrapps.mapcompose.ui.MapUI
 import ru.spbu.depnav.R
-import ru.spbu.depnav.data.model.Marker
-import ru.spbu.depnav.data.model.MarkerText
+import ru.spbu.depnav.data.composite.MarkerWithText
 import ru.spbu.depnav.ui.component.FloorSwitch
 import ru.spbu.depnav.ui.component.MapSearchBar
 import ru.spbu.depnav.ui.component.MarkerInfoLines
@@ -76,6 +76,7 @@ import ru.spbu.depnav.ui.theme.DEFAULT_PADDING
 import ru.spbu.depnav.ui.viewmodel.MapUiState
 import ru.spbu.depnav.ui.viewmodel.MapViewModel
 import ru.spbu.depnav.ui.viewmodel.SearchUiState
+import ru.spbu.depnav.utils.map.getMarkerAlpha
 
 /** Screen containing a navigable map. */
 @Composable
@@ -126,9 +127,13 @@ fun MapScreen(vm: MapViewModel = viewModel()) {
                     onFloorSwitch = vm::setFloor
                 )
 
+                val markersVisible by remember {
+                    derivedStateOf { mapUiState.mapState.getMarkerAlpha() > 0f }
+                }
+
                 AnimatedBottom(
                     pinnedMarker = mapUiState.pinnedMarker,
-                    showZoomInHint = !vm.markersVisible
+                    showZoomInHint = !markersVisible
                 )
             }
         }
@@ -141,7 +146,7 @@ private fun BoxScope.AnimatedSearchBar(
     visible: Boolean,
     query: String,
     onQueryChange: (String) -> Unit,
-    searchResults: Map<Marker, MarkerText>,
+    searchResults: List<MarkerWithText>,
     onResultClick: (Int) -> Unit,
     onInfoCLick: () -> Unit,
     onSettingsClick: () -> Unit
@@ -215,10 +220,7 @@ private fun BoxScope.AnimatedFloorSwitch(
 }
 
 @Composable
-private fun BoxScope.AnimatedBottom(
-    pinnedMarker: Pair<Marker, MarkerText>?,
-    showZoomInHint: Boolean
-) {
+private fun BoxScope.AnimatedBottom(pinnedMarker: MarkerWithText?, showZoomInHint: Boolean) {
     val insetsNoTop = WindowInsets.systemBars.run { exclude(only(WindowInsetsSides.Top)) }
 
     // Not using insets here to let the Surface reside under bottom bar

--- a/app/src/main/java/ru/spbu/depnav/ui/viewmodel/MapViewModel.kt
+++ b/app/src/main/java/ru/spbu/depnav/ui/viewmodel/MapViewModel.kt
@@ -36,6 +36,7 @@ import kotlinx.coroutines.flow.debounce
 import kotlinx.coroutines.flow.distinctUntilChangedBy
 import kotlinx.coroutines.flow.filter
 import kotlinx.coroutines.flow.flowOn
+import kotlinx.coroutines.flow.getAndUpdate
 import kotlinx.coroutines.flow.launchIn
 import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.flow.mapLatest
@@ -248,11 +249,14 @@ class MapViewModel @Inject constructor(
             }.toMap()
         }
 
-        state.value = MapViewModelState(
-            mapName = mapName,
-            mapState = mapState,
-            floors = floors
-        )
+
+        state.getAndUpdate {
+            MapViewModelState(
+                mapName = mapName,
+                mapState = mapState,
+                floors = floors
+            )
+        }.mapState?.shutdown() // Shutdown the previous map state, if any
 
         setFloor(checkNotNull(floors.keys.firstOrNull()) { "Map has no floors" })
     }

--- a/app/src/main/java/ru/spbu/depnav/utils/map/Clustering.kt
+++ b/app/src/main/java/ru/spbu/depnav/utils/map/Clustering.kt
@@ -1,0 +1,94 @@
+/**
+ * DepNav -- department navigator.
+ * Copyright (C) 2022  Timofei Pushkin
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+package ru.spbu.depnav.utils.map
+
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.State
+import androidx.compose.runtime.derivedStateOf
+import androidx.compose.runtime.getValue
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.alpha
+import ovh.plrapps.mapcompose.api.ExperimentalClusteringApi
+import ovh.plrapps.mapcompose.api.addClusterer
+import ovh.plrapps.mapcompose.ui.state.MapState
+import ru.spbu.depnav.data.model.Marker
+import ru.spbu.depnav.ui.component.MAX_MARKER_CLUSTER_VIEW_SIZE
+import ru.spbu.depnav.ui.component.MarkersCluster
+
+private const val ROOMS_CLUSTERER_ID = "rooms"
+private const val ENTRANCE_CLUSTERER_ID = "entrances"
+private const val STAIRS_CLUSTERER_ID = "stairs"
+private const val ELEVATOR_CLUSTERER_ID = "elevators"
+private const val WC_CLUSTERER_ID = "wcs"
+private const val OTHER_CLUSTERER_ID = "others"
+
+@OptIn(ExperimentalClusteringApi::class)
+fun MapState.addClusterers() {
+    val clusterAlphaState = derivedStateOf { getMarkerAlpha() }
+    addClusterer(
+        ROOMS_CLUSTERER_ID,
+        clusteringThreshold = MAX_MARKER_CLUSTER_VIEW_SIZE,
+        clusterFactory = createClusterFactory(clusterAlphaState, Marker.MarkerType.ROOM)
+    )
+    addClusterer(
+        ENTRANCE_CLUSTERER_ID,
+        clusteringThreshold = MAX_MARKER_CLUSTER_VIEW_SIZE,
+        clusterFactory = createClusterFactory(clusterAlphaState, Marker.MarkerType.ENTRANCE)
+    )
+    addClusterer(
+        STAIRS_CLUSTERER_ID,
+        clusteringThreshold = MAX_MARKER_CLUSTER_VIEW_SIZE,
+        clusterFactory = createClusterFactory(clusterAlphaState, Marker.MarkerType.STAIRS_BOTH)
+    )
+    addClusterer(
+        ELEVATOR_CLUSTERER_ID,
+        clusteringThreshold = MAX_MARKER_CLUSTER_VIEW_SIZE,
+        clusterFactory = createClusterFactory(clusterAlphaState, Marker.MarkerType.ELEVATOR)
+    )
+    addClusterer(
+        WC_CLUSTERER_ID,
+        clusteringThreshold = MAX_MARKER_CLUSTER_VIEW_SIZE,
+        clusterFactory = createClusterFactory(clusterAlphaState, Marker.MarkerType.WC)
+    )
+    addClusterer(
+        OTHER_CLUSTERER_ID,
+        clusteringThreshold = MAX_MARKER_CLUSTER_VIEW_SIZE,
+        clusterFactory = createClusterFactory(clusterAlphaState, Marker.MarkerType.OTHER)
+    )
+}
+
+private fun createClusterFactory(alphaState: State<Float>, type: Marker.MarkerType) =
+    { ids: List<String> ->
+        @Composable {
+            val alpha by alphaState
+            if (alpha > 0f) { // To not consume clicks when invisible
+                MarkersCluster(ids, type, modifier = Modifier.alpha(alpha))
+            }
+        }
+    }
+
+fun getClustererId(markerType: Marker.MarkerType) = when (markerType) {
+    Marker.MarkerType.ROOM -> ROOMS_CLUSTERER_ID
+    Marker.MarkerType.ENTRANCE -> ENTRANCE_CLUSTERER_ID
+    Marker.MarkerType.STAIRS_UP, Marker.MarkerType.STAIRS_DOWN, Marker.MarkerType.STAIRS_BOTH ->
+        STAIRS_CLUSTERER_ID
+    Marker.MarkerType.ELEVATOR -> ELEVATOR_CLUSTERER_ID
+    Marker.MarkerType.WC_MAN, Marker.MarkerType.WC_WOMAN, Marker.MarkerType.WC -> WC_CLUSTERER_ID
+    Marker.MarkerType.OTHER -> OTHER_CLUSTERER_ID
+}

--- a/app/src/main/java/ru/spbu/depnav/utils/map/Clustering.kt
+++ b/app/src/main/java/ru/spbu/depnav/utils/map/Clustering.kt
@@ -38,6 +38,7 @@ private const val ELEVATOR_CLUSTERER_ID = "elevators"
 private const val WC_CLUSTERER_ID = "wcs"
 private const val OTHER_CLUSTERER_ID = "others"
 
+/** Adds clusterers for each marker type group. */
 @OptIn(ExperimentalClusteringApi::class)
 fun MapState.addClusterers() {
     val clusterAlphaState = derivedStateOf { getMarkerAlpha() }
@@ -83,6 +84,7 @@ private fun createClusterFactory(alphaState: State<Float>, type: Marker.MarkerTy
         }
     }
 
+/** Returns ID of the clustersr responsible for the specified marker type. */
 fun getClustererId(markerType: Marker.MarkerType) = when (markerType) {
     Marker.MarkerType.ROOM -> ROOMS_CLUSTERER_ID
     Marker.MarkerType.ENTRANCE -> ENTRANCE_CLUSTERER_ID

--- a/app/src/main/java/ru/spbu/depnav/utils/map/Floor.kt
+++ b/app/src/main/java/ru/spbu/depnav/utils/map/Floor.kt
@@ -16,16 +16,15 @@
  * along with this program.  If not, see <https://www.gnu.org/licenses/>.
  */
 
-package ru.spbu.depnav.utils.tiles
+package ru.spbu.depnav.utils.map
 
 import ovh.plrapps.mapcompose.core.TileStreamProvider
-import ru.spbu.depnav.data.model.Marker
-import ru.spbu.depnav.data.model.MarkerText
+import ru.spbu.depnav.data.composite.MarkerWithText
 
 /** Displayable floor of a map. */
 data class Floor(
     /** Layers of tiles that this floor consist of. */
     val layers: Iterable<TileStreamProvider>,
     /** Markers placed on this floor, mapped by their IDs. */
-    val markers: Map<String, Pair<Marker, MarkerText>>
+    val markers: Map<String, MarkerWithText>
 )

--- a/app/src/main/java/ru/spbu/depnav/utils/map/MarkerAlpha.kt
+++ b/app/src/main/java/ru/spbu/depnav/utils/map/MarkerAlpha.kt
@@ -1,0 +1,16 @@
+package ru.spbu.depnav.utils.map
+
+import ovh.plrapps.mapcompose.api.maxScale
+import ovh.plrapps.mapcompose.api.minScale
+import ovh.plrapps.mapcompose.api.scale
+import ovh.plrapps.mapcompose.ui.state.MapState
+
+private const val MARKERS_INVISIBLE_UNTIL_SCALE = 0.2f
+private const val MARKERS_FULLY_VISIBLE_FROM_SCALE = 0.5f
+
+fun MapState.getMarkerAlpha(): Float {
+    val minScale = minScale.coerceAtLeast(MARKERS_INVISIBLE_UNTIL_SCALE)
+    val maxScale = maxScale.coerceAtMost(MARKERS_FULLY_VISIBLE_FROM_SCALE)
+    val scale = scale.coerceIn(minScale, maxScale)
+    return (scale - minScale) / (maxScale - minScale)
+}

--- a/app/src/main/java/ru/spbu/depnav/utils/map/MarkerAlpha.kt
+++ b/app/src/main/java/ru/spbu/depnav/utils/map/MarkerAlpha.kt
@@ -8,6 +8,7 @@ import ovh.plrapps.mapcompose.ui.state.MapState
 private const val MARKERS_INVISIBLE_UNTIL_SCALE = 0.2f
 private const val MARKERS_FULLY_VISIBLE_FROM_SCALE = 0.5f
 
+/** Returns alpha value to use for map markers calculated based on the current map scale. */
 fun MapState.getMarkerAlpha(): Float {
     val minScale = minScale.coerceAtLeast(MARKERS_INVISIBLE_UNTIL_SCALE)
     val maxScale = maxScale.coerceAtMost(MARKERS_FULLY_VISIBLE_FROM_SCALE)

--- a/app/src/main/java/ru/spbu/depnav/utils/map/TileStreamProviderFactory.kt
+++ b/app/src/main/java/ru/spbu/depnav/utils/map/TileStreamProviderFactory.kt
@@ -16,7 +16,7 @@
  * along with this program.  If not, see <https://www.gnu.org/licenses/>.
  */
 
-package ru.spbu.depnav.utils.tiles
+package ru.spbu.depnav.utils.map
 
 import android.content.Context
 import android.content.res.AssetManager
@@ -26,7 +26,7 @@ import dagger.hilt.android.scopes.ViewModelScoped
 import ovh.plrapps.mapcompose.core.TileStreamProvider
 import javax.inject.Inject
 
-private const val TAG = "TileProviderFactory"
+private const val TAG = "TileStreamProviderFactory"
 
 /** Factory for creating [TileStreamProviders][TileStreamProvider] for tiles from a certain path. */
 @ViewModelScoped

--- a/app/src/main/res/values-ru/strings.xml
+++ b/app/src/main/res/values-ru/strings.xml
@@ -45,6 +45,7 @@
     <string name="label_wc_woman_icon">Женский туалет</string>
     <string name="label_wc_icon">Общий туалет</string>
     <string name="label_other_icon">Иное место</string>
+    <string name="label_non_room_cluster">Множество мест</string>
     <string name="label_selected_place">Выбранное место</string>
     <string name="label_open_map_info">Открыть информацию о карте</string>
     <string name="label_open_settings">Открыть настройки</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -49,6 +49,7 @@
     <string name="label_wc_woman_icon">Women\'s restroom</string>
     <string name="label_wc_icon">Unisex restroom</string>
     <string name="label_other_icon">Miscellaneous place</string>
+    <string name="label_non_room_cluster">Many places</string>
     <string name="label_selected_place">Selected place</string>
     <string name="label_open_map_info">Open map info</string>
     <string name="label_open_settings">Open settings</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -49,7 +49,7 @@
     <string name="label_wc_woman_icon">Women\'s restroom</string>
     <string name="label_wc_icon">Unisex restroom</string>
     <string name="label_other_icon">Miscellaneous place</string>
-    <string name="label_non_room_cluster">Many places</string>
+    <string name="label_non_room_cluster">Cluster of several places</string>
     <string name="label_selected_place">Selected place</string>
     <string name="label_open_map_info">Open map info</string>
     <string name="label_open_settings">Open settings</string>

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -26,7 +26,7 @@ androidx-compose-bom = "androidx.compose:compose-bom:2023.10.01"
 
 androidx-core-ktx = "androidx.core:core-ktx:1.12.0"
 androidx-activity-compose = "androidx.activity:activity-compose:1.8.0"
-plrapps-mapcompose = "ovh.plrapps:mapcompose:2.9.4"
+plrapps-mapcompose = "ovh.plrapps:mapcompose:2.9.5"
 
 junit = "junit:junit:4.13.2"
 androidx-test-runner = "androidx.test:runner:1.5.2"


### PR DESCRIPTION
Closes #49.

- Clustering fully replaces lazy-loading
- Clustering is done for all markers using different clusterers for different marker types
- For rooms, common title prefix is shown in the cluster composable