### PR TITLE
Fix color of contents of marker cluster view

### DIFF
--- a/app/src/main/java/ru/spbu/depnav/ui/component/MarkerCluster.kt
+++ b/app/src/main/java/ru/spbu/depnav/ui/component/MarkerCluster.kt
@@ -83,7 +83,8 @@ private fun RoomMarkersCluster(markerIds: List<String>, modifier: Modifier = Mod
             )
             .then(modifier),
         shape = MaterialTheme.shapes.small,
-        color = MaterialTheme.colorScheme.onBackground
+        color = MaterialTheme.colorScheme.onBackground,
+        contentColor = MaterialTheme.colorScheme.background
     ) {
         Box(contentAlignment = Alignment.Center) {
             Text(
@@ -108,7 +109,8 @@ private fun NonRoomMarkersCluster(painter: Painter, modifier: Modifier = Modifie
             )
             .then(modifier),
         shape = MaterialTheme.shapes.extraSmall,
-        color = MaterialTheme.colorScheme.onBackground
+        color = MaterialTheme.colorScheme.onBackground,
+        contentColor = MaterialTheme.colorScheme.background
     ) {
         Box(contentAlignment = Alignment.Center) {
             Icon(


### PR DESCRIPTION
Contents of cluster view are now explicitly set to have the proper color